### PR TITLE
Various fixes: consumer id uniqueness, connect retry, pump recovery

### DIFF
--- a/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
@@ -120,6 +120,42 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
             Connect().Until(OnError);
         }
 
+        // Startup race. A worker boots before the arena is listening, so the first
+        // connect is refused. The error path retries - but that retry can land while
+        // the client is still transitioning (Connecting), and a deferred attempt used
+        // to return Disposable.Empty, which abandoned the chain permanently: nothing
+        // ever rescheduled. The worker then settled on the AppStatus fallback channel,
+        // so the arena never saw its status, WorkerDiscovered never fired, the worker
+        // pool stayed empty, and every dispatch hung with no error (VMSS 2026-08-25).
+        public const int ConnectRetrySeconds = 2;
+
+        /// <summary>
+        /// True while the transport is mid-transition, so an attempt now would be a
+        /// no-op. Deferring is correct; abandoning is not.
+        /// </summary>
+        public static bool ShouldDeferConnect(HubConnectionState state)
+        {
+            return state != HubConnectionState.Disconnected;
+        }
+
+        /// <summary>
+        /// Re-arms a deferred attempt: wait, look again, and fire as soon as the
+        /// transport is Disconnected. Stops the moment it reaches Connected, so a
+        /// healthy fleet pays nothing for this.
+        /// </summary>
+        public static IDisposable DeferConnect(IScheduler scheduler, Func<HubConnectionState> currentState, Action attempt, TimeSpan delay)
+        {
+            return Observable.Interval(delay, scheduler)
+                .TakeWhile(_ => currentState() != HubConnectionState.Connected)
+                .Where(_ => !ShouldDeferConnect(currentState()))
+                .Take(1)
+                .Do(_ => attempt())
+                // Until, not Subscribe: a throw out of attempt() is reported rather than
+                // surfacing as an unobserved exception - which is the exact failure mode this
+                // whole retry path exists to recover from.
+                .Until(e => $"SignalR deferred connect attempt failed: {e}".LogDebug());
+        }
+
         /// <summary>
         /// Connects to the SignalR hub specified in the Url
         /// </summary>
@@ -142,8 +178,9 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
                         connect = () =>
                         {
 
-                            //already connecting?
-                            if (client.State != HubConnectionState.Disconnected) return Disposable.Empty;
+                            //already connecting? defer and look again - never abandon.
+                            if (ShouldDeferConnect(client.State))
+                                return DeferConnect(DefaultScheduler, () => client.State, () => connect(), TimeSpan.FromSeconds(ConnectRetrySeconds));
 
                             lock (_isConnectedResources)
                             {

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
@@ -120,18 +120,13 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
             Connect().Until(OnError);
         }
 
-        // Startup race. A worker boots before the arena is listening, so the first
-        // connect is refused. The error path retries - but that retry can land while
-        // the client is still transitioning (Connecting), and a deferred attempt used
-        // to return Disposable.Empty, which abandoned the chain permanently: nothing
-        // ever rescheduled. The worker then settled on the AppStatus fallback channel,
-        // so the arena never saw its status, WorkerDiscovered never fired, the worker
-        // pool stayed empty, and every dispatch hung with no error (VMSS 2026-08-25).
+        // Startup race: a client that boots before its server is listening is refused, and the
+        // retry can land while the transport is still Connecting. Deferring must re-arm - a
+        // deferral that drops the chain leaves the client silently on the fallback channel.
         public const int ConnectRetrySeconds = 2;
 
         /// <summary>
-        /// True while the transport is mid-transition, so an attempt now would be a
-        /// no-op. Deferring is correct; abandoning is not.
+        /// True while the transport is mid-transition, so an attempt now would be a no-op.
         /// </summary>
         public static bool ShouldDeferConnect(HubConnectionState state)
         {
@@ -139,9 +134,8 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
         }
 
         /// <summary>
-        /// Re-arms a deferred attempt: wait, look again, and fire as soon as the
-        /// transport is Disconnected. Stops the moment it reaches Connected, so a
-        /// healthy fleet pays nothing for this.
+        /// Re-arms a deferred attempt: wait, look again, fire once the transport is Disconnected.
+        /// Stops on Connected, so a healthy fleet pays nothing for it.
         /// </summary>
         public static IDisposable DeferConnect(IScheduler scheduler, Func<HubConnectionState> currentState, Action attempt, TimeSpan delay)
         {
@@ -150,9 +144,8 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
                 .Where(_ => !ShouldDeferConnect(currentState()))
                 .Take(1)
                 .Do(_ => attempt())
-                // Until, not Subscribe: a throw out of attempt() is reported rather than
-                // surfacing as an unobserved exception - which is the exact failure mode this
-                // whole retry path exists to recover from.
+                // Until, not Subscribe: a throw out of attempt() is reported rather than becoming
+                // an unobserved exception.
                 .Until(e => $"SignalR deferred connect attempt failed: {e}".LogDebug());
         }
 
@@ -178,7 +171,7 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
                         connect = () =>
                         {
 
-                            //already connecting? defer and look again - never abandon.
+                            //already connecting? defer and look again
                             if (ShouldDeferConnect(client.State))
                                 return DeferConnect(DefaultScheduler, () => client.State, () => connect(), TimeSpan.FromSeconds(ConnectRetrySeconds));
 

--- a/src/Rxns.Redis/RedisInboundEventPump.cs
+++ b/src/Rxns.Redis/RedisInboundEventPump.cs
@@ -54,10 +54,8 @@ namespace Rxns.Redis
             _localBus = localBus;
         }
 
-        // A source fault used to kill the pump for good: Subscribe had no onError,
-        // so a Redis blip terminated the sequence and nothing ever resubscribed.
-        // Lossless mode then looked healthy while silently carrying nothing - the
-        // same shape as the SignalR startup race, one layer down.
+        // A source fault must not end the pump: without a resubscribe, a Redis blip leaves
+        // lossless mode looking healthy while carrying nothing.
         public const int ResubscribeSeconds = 2;
 
         /// <summary>
@@ -87,10 +85,8 @@ namespace Rxns.Redis
                     // the event had arrived in-process.
                     .Do(rxn => _localBus.Publish(rxn)
                         .Until(e => OnError(new Exception("Local bus republish failed", e))))
-                    // Until, not Subscribe: it catches and reports faults instead of letting one
-                    // bad event tear the pump down, which is the whole point of the resubscribe
-                    // above. A raw Subscribe with a hand-rolled try/catch duplicates what the
-                    // primitive already guarantees.
+                    // Until, not Subscribe: reports a fault instead of letting one bad event tear
+                    // the pump down.
                     .Until(e => OnError(new Exception("RedisInboundEventPump dispatch failed", e)));
 
                 _resources.Add(sub);

--- a/src/Rxns.Redis/RedisInboundEventPump.cs
+++ b/src/Rxns.Redis/RedisInboundEventPump.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Rxns.DDD.Commanding;
@@ -53,6 +54,23 @@ namespace Rxns.Redis
             _localBus = localBus;
         }
 
+        // A source fault used to kill the pump for good: Subscribe had no onError,
+        // so a Redis blip terminated the sequence and nothing ever resubscribed.
+        // Lossless mode then looked healthy while silently carrying nothing - the
+        // same shape as the SignalR startup race, one layer down.
+        public const int ResubscribeSeconds = 2;
+
+        /// <summary>
+        /// Resubscribes to <paramref name="source"/> after a fault, so the pump
+        /// survives a transport blip instead of dying silently.
+        /// </summary>
+        public static IObservable<T> KeepSubscribed<T>(Func<IObservable<T>> source, IScheduler scheduler, TimeSpan delay)
+        {
+            return Rxn.DfrCreate(source)
+                .Catch<T, Exception>(e => Observable.Throw<T>(e).DelaySubscription(delay, scheduler))
+                .Retry();
+        }
+
         public IObservable<CommandResult> Start(string from = null, string options = null)
         {
             // Only Redis-backed clients expose an Incoming observable; SignalR
@@ -63,24 +81,18 @@ namespace Rxns.Redis
             if (_appStatus is RedisAppStatusServiceClient redisClient)
             {
                 OnInformation("RedisInboundEventPump: piping RedisAppStatusServiceClient.Incoming -> local IRxnManager");
-                var sub = redisClient.Incoming
-                    .Subscribe(rxn =>
-                    {
-                        try
-                        {
-                            // Publish onto the local bus so type-based
-                            // subscriptions (RedisEventHub.WorkerHeartbeat,
-                            // command handlers, UI bridges) fire as if the
-                            // event had arrived in-process. .Until handles
-                            // any errors from downstream subscribers without
-                            // killing the pump.
-                            _localBus.Publish(rxn).Until(e => OnError(new Exception("Local bus republish failed", e)));
-                        }
-                        catch (Exception ex)
-                        {
-                            OnError(new Exception("RedisInboundEventPump dispatch failed", ex));
-                        }
-                    });
+                var sub = KeepSubscribed(() => redisClient.Incoming, TaskPoolScheduler.Default, TimeSpan.FromSeconds(ResubscribeSeconds))
+                    // Publish onto the local bus so type-based subscriptions
+                    // (RedisEventHub.WorkerHeartbeat, command handlers, UI bridges) fire as if
+                    // the event had arrived in-process.
+                    .Do(rxn => _localBus.Publish(rxn)
+                        .Until(e => OnError(new Exception("Local bus republish failed", e))))
+                    // Until, not Subscribe: it catches and reports faults instead of letting one
+                    // bad event tear the pump down, which is the whole point of the resubscribe
+                    // above. A raw Subscribe with a hand-rolled try/catch duplicates what the
+                    // primitive already guarantees.
+                    .Until(e => OnError(new Exception("RedisInboundEventPump dispatch failed", e)));
+
                 _resources.Add(sub);
             }
             else

--- a/src/Rxns.Redis/RedisStreamBackingChannel.cs
+++ b/src/Rxns.Redis/RedisStreamBackingChannel.cs
@@ -122,13 +122,10 @@ namespace Rxns.Redis
         /// <summary>
         /// Per-process consumer id. MUST be unique: the poll loop treats an entry whose
         /// <c>from</c> equals this id as self-published and skip-and-acks it silently.
-        /// <para>The old form was <c>$"{MachineName}-{Guid}".Substring(0, 20)</c>, which threw the
-        /// GUID away entirely whenever the machine name was >= 20 chars. Every VMSS instance is
-        /// named <c>&lt;cluster&gt;00000N</c> (23 chars), so all of them collapsed to the SAME id -
-        /// e.g. <c>pwa-load-sequence000</c>. The arena then read all 187 worker heartbeats off the
-        /// stream, judged each one its own, acked it and delivered nothing. No error, no log: the
-        /// worker pool stayed empty and StartUnitTest was dispatched into nothing, so the run hung
-        /// after upload. Truncate the HOST part if you must, never the entropy.</para>
+        /// <para>Collisions are silent, so truncate the host part if you must - never the entropy.
+        /// Hosts sharing a prefix are the common case (a VMSS names its instances
+        /// <c>&lt;cluster&gt;00000N</c>), and a collision leaves every node discarding the others'
+        /// events as its own echo.</para>
         /// </summary>
         public static string MakeConsumerId(string machineName)
         {

--- a/src/Rxns.Redis/RedisStreamBackingChannel.cs
+++ b/src/Rxns.Redis/RedisStreamBackingChannel.cs
@@ -73,7 +73,7 @@ namespace Rxns.Redis
         {
             _streamName = streamName;
             _consumerGroup = consumerGroup ?? $"{streamName}-group";
-            _consumerId = $"{Environment.MachineName}-{Guid.NewGuid():N}".Substring(0, 20);
+            _consumerId = MakeConsumerId(Environment.MachineName);
             // Mode wins when explicitly set; otherwise fall back to the legacy
             // publishOnly bool so existing call-sites keep working unchanged.
             _mode = mode ?? (publishOnly ? RedisStreamMode.PublishOnly : RedisStreamMode.Bidirectional);
@@ -117,6 +117,24 @@ namespace Rxns.Redis
                 _cts = new CancellationTokenSource();
                 Task.Run(() => PollStream(_cts.Token));
             }
+        }
+
+        /// <summary>
+        /// Per-process consumer id. MUST be unique: the poll loop treats an entry whose
+        /// <c>from</c> equals this id as self-published and skip-and-acks it silently.
+        /// <para>The old form was <c>$"{MachineName}-{Guid}".Substring(0, 20)</c>, which threw the
+        /// GUID away entirely whenever the machine name was >= 20 chars. Every VMSS instance is
+        /// named <c>&lt;cluster&gt;00000N</c> (23 chars), so all of them collapsed to the SAME id -
+        /// e.g. <c>pwa-load-sequence000</c>. The arena then read all 187 worker heartbeats off the
+        /// stream, judged each one its own, acked it and delivered nothing. No error, no log: the
+        /// worker pool stayed empty and StartUnitTest was dispatched into nothing, so the run hung
+        /// after upload. Truncate the HOST part if you must, never the entropy.</para>
+        /// </summary>
+        public static string MakeConsumerId(string machineName)
+        {
+            var host = string.IsNullOrWhiteSpace(machineName) ? "host" : machineName;
+            if (host.Length > 12) host = host.Substring(0, 12);
+            return $"{host}-{Guid.NewGuid():N}";
         }
 
         public IObservable<T> Setup(IDeliveryScheme<T> postman)


### PR DESCRIPTION
## Consumer id uniqueness

`RedisStreamBackingChannel` built its consumer id as `$"{MachineName}-{Guid}".Substring(0, 20)`. Any machine name of 20+ characters truncates the GUID away, so every process on a same-prefixed host gets the same id. Azure VMSS instances are named `<cluster>00000N` (23 chars).

The poll loop treats an entry whose `from` matches its own id as self-published and skip-acks it — silently, to break publish/consume cycles. With ids colliding, each node discards every other node's events: 187 worker heartbeats read, acked, none delivered. `XINFO GROUPS` shows one consumer because the nodes share a name.

`MakeConsumerId` truncates the host portion and keeps the full GUID.

## Connect retry

`SignalRRxnManagerBridge` returned `Disposable.Empty` when a connect attempt landed while the client was mid-transition, leaving nothing scheduled. A worker that starts before the arena is listening therefore stopped retrying after the first refusal. Deferred attempts now re-arm and stop once `Connected`.

## Inbound pump resilience

`RedisInboundEventPump` subscribed with no `onError`, so one source fault ended the subscription permanently and lossless mode reported healthy while carrying nothing. It now resubscribes after a fault.

Both paths use `Rxn.DfrCreate` / `.Until` rather than raw `Observable.Defer` / `.Subscribe`.

## Verification

`RedisConsumerIdBehaviour`, `SignalRConnectRaceBehaviour`, `RedisPumpRecoveryBehaviour` in theBFG.Tests. Reverting each fix fails 3/5, 2/5 and 2/3 respectively. Confirmed on a 3-instance cluster: distinct ids per node, both workers registered, pool 2/2, dispatch delivered.

Cut against `master` — `vnext` is not pushed, so basing there would pull in 9 unrelated commits.