### PR TITLE
Various fixes: consumer id uniqueness, connect retry, pump recovery

### DIFF
--- a/Rxns.AppSatus/Web/dist/index.html
+++ b/Rxns.AppSatus/Web/dist/index.html
@@ -34,7 +34,7 @@
     <!-- Add New Shared Component JS Above -->
 
     <!--
-        Augment slot: the augmented portal hosts (e.g. Janison.SupportPortal) drop
+        Augment slot: the augmented portal hosts (e.g. YourApp.SupportPortal) drop
         an /augment/init.js into the augment static root, where it pushes nav +
         state descriptors into window.RxnsPortalAugments BEFORE app.js bootstraps
         angular. Hosts without an augment 404 here and the onerror=this.remove

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/AspNetCoreWebApiAdapter.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/AspNetCoreWebApiAdapter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reactive;
 using System.Threading.Tasks;
 using Autofac.Extensions.DependencyInjection;
@@ -49,7 +49,7 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
                 var host = Host.CreateDefaultBuilder(args)
                     .UseEnvironment("Development")
                     .UseServiceProviderFactory(new AutofacServiceProviderFactory())
-                    .ConfigureLogging((a, l) => { l.ClearProviders(); l.AddProvider(new RxnsLogDebugProvider()); l.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Information); })
+                    .ConfigureLogging((a, l) => { l.ClearProviders(); l.AddProvider(new RxnsLogDebugProvider()); /* Trace, so the host filters nothing and RxnsLogVerbosity decides - see RxnsLogVerbosity for why the level has to stay changeable at runtime. */ l.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace); })
                     .ConfigureWebHostDefaults(webHostBuilder =>
                     {
                         webHostBuilder

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/AspNetCoreWebApiAdapter.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/AspNetCoreWebApiAdapter.cs
@@ -46,6 +46,10 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
             try
             {
 
+                // Before the host builds: the pool floor governs how a burst is served, and the pool
+                // cannot be usefully raised once requests are already queueing for a thread.
+                RxnsHostTuning.ApplyThreadFloor();
+
                 var host = Host.CreateDefaultBuilder(args)
                     .UseEnvironment("Development")
                     .UseServiceProviderFactory(new AutofacServiceProviderFactory())
@@ -64,6 +68,10 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
                             // Html5Root directly via its own FileProvider.
                             .UseWebRoot(cfg.Html5Root)
                             .CaptureStartupErrors(true)
+                            // A longer accept backlog so a host that falls behind queues its pending
+                            // connections instead of having the kernel drop them - a dropped SYN is
+                            // invisible here and costs the client a multi-second TCP retransmit.
+                            .UseSockets(sock => sock.Backlog = RxnsHostTuning.AcceptBacklog)
                             .UseKestrel(opts => {
                                 // Default Kestrel cap is 30 MB. 250 MB matches the
                                 // per-route RequestSizeLimit attribute on

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/RxnsApiAdapters/SystemStatusController.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/RxnsApiAdapters/SystemStatusController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -33,7 +33,12 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters.RxnsApiAdapters
         {
             this.TryCatch(() =>
             {
-                OnInformation("Received status from '{0}\\{1}'", status.Tenant, status.SystemName);
+                // Verbose, not Info: in rxns a log message is itself a published event, so at Info
+                // every heartbeat cost a second event through the same channel it arrived on. At a
+                // fleet's heartbeat rate that amplification is the dominant load, and the arena stops
+                // accepting HTTP with nothing in the log to say why. Liveness is already in the store
+                // this call updates, so nothing is lost by dropping the announcement a level.
+                OnVerbose("Received status from '{0}\\{1}'", status.Tenant, status.SystemName);
 
                 status.IpAddress = GetRequestIP();
 

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/RxnsHostTuning.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/RxnsHostTuning.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+
+namespace Rxns.WebApiNET5.NET5WebApiAdapters
+{
+    /// <summary>
+    /// Host settings that only matter under load, and only on small machines.
+    ///
+    /// <para>Two defaults in the stack are wrong for a coordinator that fields a fleet's worth of
+    /// small requests on two cores. The thread pool starts at about one thread per core and adds a
+    /// couple a second, so a burst is served at the rate the pool grows rather than the rate the work
+    /// arrives. And the socket accept backlog is short, so a host that falls behind has its pending
+    /// connections dropped by the kernel - the client then waits out a TCP retransmit, which is
+    /// seconds, and reports a failure the host never saw.</para>
+    ///
+    /// <para>A longer backlog is the more forgiving of the two failure modes: a queue drains when the
+    /// spike passes and nothing is lost, whereas a dropped SYN is invisible to the server and costs
+    /// the client seconds. Neither setting makes a saturated host fast - they decide how it behaves
+    /// while it catches up.</para>
+    ///
+    /// <para>Both are overridable per environment, because the right values depend on the machine and
+    /// guessing them once in code would be no better than the defaults being wrong.</para>
+    /// </summary>
+    public static class RxnsHostTuning
+    {
+        /// <summary>
+        /// Worker threads to have ready before the pool starts throttling growth. Defaults to 16 per
+        /// core, which covers a burst on a small host without the cost of parking hundreds of idle
+        /// threads. Override with RXNS_MIN_THREADS.
+        /// </summary>
+        public static int MinWorkerThreads =>
+            ReadInt("RXNS_MIN_THREADS", Math.Max(32, Environment.ProcessorCount * 16));
+
+        /// <summary>
+        /// Pending connections the kernel will hold before dropping them. Defaults to 1024 against
+        /// Kestrel's 512. Linux also caps this at net.core.somaxconn, so a larger value here is a
+        /// request rather than a guarantee. Override with RXNS_ACCEPT_BACKLOG.
+        /// </summary>
+        public static int AcceptBacklog => ReadInt("RXNS_ACCEPT_BACKLOG", 1024);
+
+        /// <summary>
+        /// Raises the pool floor. Only ever raises: another component may have set a higher floor for
+        /// its own reasons, and lowering someone else's floor from generic host startup would be a
+        /// surprising thing for this to do.
+        /// </summary>
+        public static void ApplyThreadFloor()
+        {
+            int workers, completion;
+            ThreadPool.GetMinThreads(out workers, out completion);
+
+            var wanted = MinWorkerThreads;
+            if (wanted <= workers) return;
+
+            ThreadPool.SetMinThreads(wanted, completion);
+        }
+
+        private static int ReadInt(string name, int fallback)
+        {
+            var configured = Environment.GetEnvironmentVariable(name);
+
+            int parsed;
+            return !string.IsNullOrWhiteSpace(configured) && int.TryParse(configured.Trim(), out parsed) && parsed > 0
+                ? parsed
+                : fallback;
+        }
+    }
+}

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/RxnsLogDebugProvider.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/RxnsLogDebugProvider.cs
@@ -20,7 +20,10 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
 
             public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
 
-            public bool IsEnabled(MsLogLevel logLevel) => logLevel >= MsLogLevel.Information;
+            // Delegates to the runtime setting rather than a constant, so a live host can be made
+            // chatty for a few minutes and quiet again without a restart. ASP.NET calls this before
+            // formatting a message, so a suppressed line costs a comparison and nothing else.
+            public bool IsEnabled(MsLogLevel logLevel) => logLevel >= RxnsLogVerbosity.FrameworkMinimum;
 
             public void Log<TState>(MsLogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
             {

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/RxnsLogVerbosity.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/RxnsLogVerbosity.cs
@@ -1,0 +1,93 @@
+using System;
+using MsLogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Rxns.WebApiNET5.NET5WebApiAdapters
+{
+    /// <summary>How much of the web host's own diagnostic chatter is let through.</summary>
+    public enum LogVerbosity
+    {
+        /// <summary>Every framework message from Information up - request start, routing, action, finish.</summary>
+        Diagnostics = 0,
+
+        /// <summary>Warnings and worse. The default: keeps what needs attention, drops the per-request narrative.</summary>
+        Normal = 1,
+
+        /// <summary>Errors only.</summary>
+        Minimal = 2
+    }
+
+    /// <summary>
+    /// Controls how much the ASP.NET host logs, at runtime.
+    ///
+    /// <para>This exists because framework diagnostics are not free here. Hosting, routing and MVC each
+    /// log at Information, those go through <see cref="RxnsLogDebugProvider"/>, and in rxns a log
+    /// message is itself published as an event - so a single request costs roughly four extra events
+    /// before the handler does anything. At one heartbeat per worker per cadence that is the dominant
+    /// load on the arena, and it is invisible because each line looks trivial on its own.</para>
+    ///
+    /// <para>Hardcoding a quieter level would trade that for an arena nobody can debug, so the level is
+    /// a runtime switch instead: run quiet, and turn diagnostics back on for the minutes you need them
+    /// without restarting and losing the state you were trying to look at.</para>
+    ///
+    /// <para>The host deliberately sets its own minimum to Trace and delegates the decision here.
+    /// Filtering at the host would fix the level at startup; filtering here keeps it changeable, and
+    /// costs only an IsEnabled call per message because ASP.NET checks that before formatting.</para>
+    /// </summary>
+    public static class RxnsLogVerbosity
+    {
+        private static LogVerbosity _level = ReadInitial();
+
+        /// <summary>Current level. Set it to escalate or quieten a running host.</summary>
+        public static LogVerbosity Level
+        {
+            get { return _level; }
+            set { _level = value; }
+        }
+
+        /// <summary>Lowest framework level that reaches the log at the current setting.</summary>
+        public static MsLogLevel FrameworkMinimum
+        {
+            get
+            {
+                switch (_level)
+                {
+                    case LogVerbosity.Diagnostics: return MsLogLevel.Information;
+                    case LogVerbosity.Minimal: return MsLogLevel.Error;
+                    default: return MsLogLevel.Warning;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Parses a level by name, for a config value or a remote command. Unrecognised input leaves
+        /// the level alone rather than guessing - a typo in an ops command must not silently turn
+        /// diagnostics on across a fleet.
+        /// </summary>
+        public static bool TrySet(string level)
+        {
+            if (string.IsNullOrWhiteSpace(level)) return false;
+
+            LogVerbosity parsed;
+            if (!Enum.TryParse(level.Trim(), true, out parsed)) return false;
+
+            _level = parsed;
+            return true;
+        }
+
+        /// <summary>
+        /// Starting level from RXNS_LOG_VERBOSITY. Defaults to Normal: the per-request narrative is
+        /// the expensive part and is rarely what anyone reads, while warnings and errors are both
+        /// cheap and the reason to look at all.
+        /// </summary>
+        private static LogVerbosity ReadInitial()
+        {
+            var configured = Environment.GetEnvironmentVariable("RXNS_LOG_VERBOSITY");
+
+            LogVerbosity parsed;
+            if (!string.IsNullOrWhiteSpace(configured) && Enum.TryParse(configured.Trim(), true, out parsed))
+                return parsed;
+
+            return LogVerbosity.Normal;
+        }
+    }
+}

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
@@ -120,6 +120,42 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
             Connect().Until(OnError);
         }
 
+        // Startup race. A worker boots before the arena is listening, so the first
+        // connect is refused. The error path retries - but that retry can land while
+        // the client is still transitioning (Connecting), and a deferred attempt used
+        // to return Disposable.Empty, which abandoned the chain permanently: nothing
+        // ever rescheduled. The worker then settled on the AppStatus fallback channel,
+        // so the arena never saw its status, WorkerDiscovered never fired, the worker
+        // pool stayed empty, and every dispatch hung with no error (VMSS 2026-08-25).
+        public const int ConnectRetrySeconds = 2;
+
+        /// <summary>
+        /// True while the transport is mid-transition, so an attempt now would be a
+        /// no-op. Deferring is correct; abandoning is not.
+        /// </summary>
+        public static bool ShouldDeferConnect(HubConnectionState state)
+        {
+            return state != HubConnectionState.Disconnected;
+        }
+
+        /// <summary>
+        /// Re-arms a deferred attempt: wait, look again, and fire as soon as the
+        /// transport is Disconnected. Stops the moment it reaches Connected, so a
+        /// healthy fleet pays nothing for this.
+        /// </summary>
+        public static IDisposable DeferConnect(IScheduler scheduler, Func<HubConnectionState> currentState, Action attempt, TimeSpan delay)
+        {
+            return Observable.Interval(delay, scheduler)
+                .TakeWhile(_ => currentState() != HubConnectionState.Connected)
+                .Where(_ => !ShouldDeferConnect(currentState()))
+                .Take(1)
+                .Do(_ => attempt())
+                // Until, not Subscribe: a throw out of attempt() is reported rather than
+                // surfacing as an unobserved exception - which is the exact failure mode this
+                // whole retry path exists to recover from.
+                .Until(e => $"SignalR deferred connect attempt failed: {e}".LogDebug());
+        }
+
         /// <summary>
         /// Connects to the SignalR hub specified in the Url
         /// </summary>
@@ -142,8 +178,9 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
                         connect = () =>
                         {
 
-                            //already connecting?
-                            if (client.State != HubConnectionState.Disconnected) return Disposable.Empty;
+                            //already connecting? defer and look again - never abandon.
+                            if (ShouldDeferConnect(client.State))
+                                return DeferConnect(DefaultScheduler, () => client.State, () => connect(), TimeSpan.FromSeconds(ConnectRetrySeconds));
 
                             lock (_isConnectedResources)
                             {

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
@@ -120,18 +120,13 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
             Connect().Until(OnError);
         }
 
-        // Startup race. A worker boots before the arena is listening, so the first
-        // connect is refused. The error path retries - but that retry can land while
-        // the client is still transitioning (Connecting), and a deferred attempt used
-        // to return Disposable.Empty, which abandoned the chain permanently: nothing
-        // ever rescheduled. The worker then settled on the AppStatus fallback channel,
-        // so the arena never saw its status, WorkerDiscovered never fired, the worker
-        // pool stayed empty, and every dispatch hung with no error (VMSS 2026-08-25).
+        // Startup race: a client that boots before its server is listening is refused, and the
+        // retry can land while the transport is still Connecting. Deferring must re-arm - a
+        // deferral that drops the chain leaves the client silently on the fallback channel.
         public const int ConnectRetrySeconds = 2;
 
         /// <summary>
-        /// True while the transport is mid-transition, so an attempt now would be a
-        /// no-op. Deferring is correct; abandoning is not.
+        /// True while the transport is mid-transition, so an attempt now would be a no-op.
         /// </summary>
         public static bool ShouldDeferConnect(HubConnectionState state)
         {
@@ -139,9 +134,8 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
         }
 
         /// <summary>
-        /// Re-arms a deferred attempt: wait, look again, and fire as soon as the
-        /// transport is Disconnected. Stops the moment it reaches Connected, so a
-        /// healthy fleet pays nothing for this.
+        /// Re-arms a deferred attempt: wait, look again, fire once the transport is Disconnected.
+        /// Stops on Connected, so a healthy fleet pays nothing for it.
         /// </summary>
         public static IDisposable DeferConnect(IScheduler scheduler, Func<HubConnectionState> currentState, Action attempt, TimeSpan delay)
         {
@@ -150,9 +144,8 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
                 .Where(_ => !ShouldDeferConnect(currentState()))
                 .Take(1)
                 .Do(_ => attempt())
-                // Until, not Subscribe: a throw out of attempt() is reported rather than
-                // surfacing as an unobserved exception - which is the exact failure mode this
-                // whole retry path exists to recover from.
+                // Until, not Subscribe: a throw out of attempt() is reported rather than becoming
+                // an unobserved exception.
                 .Until(e => $"SignalR deferred connect attempt failed: {e}".LogDebug());
         }
 
@@ -178,7 +171,7 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
                         connect = () =>
                         {
 
-                            //already connecting? defer and look again - never abandon.
+                            //already connecting? defer and look again
                             if (ShouldDeferConnect(client.State))
                                 return DeferConnect(DefaultScheduler, () => client.State, () => connect(), TimeSpan.FromSeconds(ConnectRetrySeconds));
 

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
@@ -120,23 +120,13 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
             Connect().Until(OnError);
         }
 
-        // Startup race: a client that boots before its server is listening is refused, and the
-        // retry can land while the transport is still Connecting. Deferring must re-arm - a
-        // deferral that drops the chain leaves the client silently on the fallback channel.
         public const int ConnectRetrySeconds = 2;
 
-        /// <summary>
-        /// True while the transport is mid-transition, so an attempt now would be a no-op.
-        /// </summary>
         public static bool ShouldDeferConnect(HubConnectionState state)
         {
             return state != HubConnectionState.Disconnected;
         }
 
-        /// <summary>
-        /// Re-arms a deferred attempt: wait, look again, fire once the transport is Disconnected.
-        /// Stops on Connected, so a healthy fleet pays nothing for it.
-        /// </summary>
         public static IDisposable DeferConnect(IScheduler scheduler, Func<HubConnectionState> currentState, Action attempt, TimeSpan delay)
         {
             return Observable.Interval(delay, scheduler)
@@ -144,8 +134,6 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
                 .Where(_ => !ShouldDeferConnect(currentState()))
                 .Take(1)
                 .Do(_ => attempt())
-                // Until, not Subscribe: a throw out of attempt() is reported rather than becoming
-                // an unobserved exception.
                 .Until(e => $"SignalR deferred connect attempt failed: {e}".LogDebug());
         }
 
@@ -171,7 +159,7 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
                         connect = () =>
                         {
 
-                            //already connecting? defer and look again
+                            //already connecting?
                             if (ShouldDeferConnect(client.State))
                                 return DeferConnect(DefaultScheduler, () => client.State, () => connect(), TimeSpan.FromSeconds(ConnectRetrySeconds));
 

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
@@ -120,7 +120,7 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
             Connect().Until(OnError);
         }
 
-        public static readonly TimeSpan ConnectRetryDelay = TimeSpan.FromSeconds(2);
+        public TimeSpan ConnectRetryDelay { get; set; } = TimeSpan.FromSeconds(2);
 
         public static bool ShouldDeferConnect(HubConnectionState state)
         {

--- a/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
+++ b/Rxns.WebApiNET5/NET5WebApiAdapters/SignalRRxnManagerBridge.cs
@@ -120,7 +120,7 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
             Connect().Until(OnError);
         }
 
-        public const int ConnectRetrySeconds = 2;
+        public static readonly TimeSpan ConnectRetryDelay = TimeSpan.FromSeconds(2);
 
         public static bool ShouldDeferConnect(HubConnectionState state)
         {
@@ -161,7 +161,7 @@ namespace Rxns.WebApiNET5.NET5WebApiAdapters
 
                             //already connecting?
                             if (ShouldDeferConnect(client.State))
-                                return DeferConnect(DefaultScheduler, () => client.State, () => connect(), TimeSpan.FromSeconds(ConnectRetrySeconds));
+                                return DeferConnect(DefaultScheduler, () => client.State, () => connect(), ConnectRetryDelay);
 
                             lock (_isConnectedResources)
                             {

--- a/src/Rxns.Redis/RedisInboundEventPump.cs
+++ b/src/Rxns.Redis/RedisInboundEventPump.cs
@@ -54,7 +54,7 @@ namespace Rxns.Redis
             _localBus = localBus;
         }
 
-        public static readonly TimeSpan ResubscribeDelay = TimeSpan.FromSeconds(2);
+        public TimeSpan ResubscribeDelay { get; set; } = TimeSpan.FromSeconds(2);
 
         public IObservable<CommandResult> Start(string from = null, string options = null)
         {

--- a/src/Rxns.Redis/RedisInboundEventPump.cs
+++ b/src/Rxns.Redis/RedisInboundEventPump.cs
@@ -54,10 +54,8 @@ namespace Rxns.Redis
             _localBus = localBus;
         }
 
-        // A source fault used to kill the pump for good: Subscribe had no onError,
-        // so a Redis blip terminated the sequence and nothing ever resubscribed.
-        // Lossless mode then looked healthy while silently carrying nothing - the
-        // same shape as the SignalR startup race, one layer down.
+        // A source fault must not end the pump: without a resubscribe, a Redis blip leaves
+        // lossless mode looking healthy while carrying nothing.
         public const int ResubscribeSeconds = 2;
 
         /// <summary>
@@ -87,10 +85,8 @@ namespace Rxns.Redis
                     // the event had arrived in-process.
                     .Do(rxn => _localBus.Publish(rxn)
                         .Until(e => OnError(new Exception("Local bus republish failed", e))))
-                    // Until, not Subscribe: it catches and reports faults instead of letting one
-                    // bad event tear the pump down, which is the whole point of the resubscribe
-                    // above. A raw Subscribe with a hand-rolled try/catch duplicates what the
-                    // primitive already guarantees.
+                    // Until, not Subscribe: reports a fault instead of letting one bad event tear
+                    // the pump down.
                     .Until(e => OnError(new Exception("RedisInboundEventPump dispatch failed", e)));
 
                 _resources.Add(sub);

--- a/src/Rxns.Redis/RedisInboundEventPump.cs
+++ b/src/Rxns.Redis/RedisInboundEventPump.cs
@@ -54,20 +54,7 @@ namespace Rxns.Redis
             _localBus = localBus;
         }
 
-        // A source fault must not end the pump: without a resubscribe, a Redis blip leaves
-        // lossless mode looking healthy while carrying nothing.
         public const int ResubscribeSeconds = 2;
-
-        /// <summary>
-        /// Resubscribes to <paramref name="source"/> after a fault, so the pump
-        /// survives a transport blip instead of dying silently.
-        /// </summary>
-        public static IObservable<T> KeepSubscribed<T>(Func<IObservable<T>> source, IScheduler scheduler, TimeSpan delay)
-        {
-            return Rxn.DfrCreate(source)
-                .Catch<T, Exception>(e => Observable.Throw<T>(e).DelaySubscription(delay, scheduler))
-                .Retry();
-        }
 
         public IObservable<CommandResult> Start(string from = null, string options = null)
         {
@@ -79,14 +66,12 @@ namespace Rxns.Redis
             if (_appStatus is RedisAppStatusServiceClient redisClient)
             {
                 OnInformation("RedisInboundEventPump: piping RedisAppStatusServiceClient.Incoming -> local IRxnManager");
-                var sub = KeepSubscribed(() => redisClient.Incoming, TaskPoolScheduler.Default, TimeSpan.FromSeconds(ResubscribeSeconds))
-                    // Publish onto the local bus so type-based subscriptions
-                    // (RedisEventHub.WorkerHeartbeat, command handlers, UI bridges) fire as if
-                    // the event had arrived in-process.
+                var sub = Rxn.DfrCreate(() => redisClient.Incoming)
+                    .Catch<IRxn, Exception>(e => Observable.Throw<IRxn>(e)
+                        .DelaySubscription(TimeSpan.FromSeconds(ResubscribeSeconds), TaskPoolScheduler.Default))
+                    .Retry()
                     .Do(rxn => _localBus.Publish(rxn)
                         .Until(e => OnError(new Exception("Local bus republish failed", e))))
-                    // Until, not Subscribe: reports a fault instead of letting one bad event tear
-                    // the pump down.
                     .Until(e => OnError(new Exception("RedisInboundEventPump dispatch failed", e)));
 
                 _resources.Add(sub);

--- a/src/Rxns.Redis/RedisInboundEventPump.cs
+++ b/src/Rxns.Redis/RedisInboundEventPump.cs
@@ -54,7 +54,7 @@ namespace Rxns.Redis
             _localBus = localBus;
         }
 
-        public const int ResubscribeSeconds = 2;
+        public static readonly TimeSpan ResubscribeDelay = TimeSpan.FromSeconds(2);
 
         public IObservable<CommandResult> Start(string from = null, string options = null)
         {
@@ -68,7 +68,7 @@ namespace Rxns.Redis
                 OnInformation("RedisInboundEventPump: piping RedisAppStatusServiceClient.Incoming -> local IRxnManager");
                 var sub = Rxn.DfrCreate(() => redisClient.Incoming)
                     .Catch<IRxn, Exception>(e => Observable.Throw<IRxn>(e)
-                        .DelaySubscription(TimeSpan.FromSeconds(ResubscribeSeconds), TaskPoolScheduler.Default))
+                        .DelaySubscription(ResubscribeDelay, TaskPoolScheduler.Default))
                     .Retry()
                     .Do(rxn => _localBus.Publish(rxn)
                         .Until(e => OnError(new Exception("Local bus republish failed", e))))

--- a/src/Rxns.Redis/RedisInboundEventPump.cs
+++ b/src/Rxns.Redis/RedisInboundEventPump.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Rxns.DDD.Commanding;
@@ -53,6 +54,23 @@ namespace Rxns.Redis
             _localBus = localBus;
         }
 
+        // A source fault used to kill the pump for good: Subscribe had no onError,
+        // so a Redis blip terminated the sequence and nothing ever resubscribed.
+        // Lossless mode then looked healthy while silently carrying nothing - the
+        // same shape as the SignalR startup race, one layer down.
+        public const int ResubscribeSeconds = 2;
+
+        /// <summary>
+        /// Resubscribes to <paramref name="source"/> after a fault, so the pump
+        /// survives a transport blip instead of dying silently.
+        /// </summary>
+        public static IObservable<T> KeepSubscribed<T>(Func<IObservable<T>> source, IScheduler scheduler, TimeSpan delay)
+        {
+            return Rxn.DfrCreate(source)
+                .Catch<T, Exception>(e => Observable.Throw<T>(e).DelaySubscription(delay, scheduler))
+                .Retry();
+        }
+
         public IObservable<CommandResult> Start(string from = null, string options = null)
         {
             // Only Redis-backed clients expose an Incoming observable; SignalR
@@ -63,24 +81,18 @@ namespace Rxns.Redis
             if (_appStatus is RedisAppStatusServiceClient redisClient)
             {
                 OnInformation("RedisInboundEventPump: piping RedisAppStatusServiceClient.Incoming -> local IRxnManager");
-                var sub = redisClient.Incoming
-                    .Subscribe(rxn =>
-                    {
-                        try
-                        {
-                            // Publish onto the local bus so type-based
-                            // subscriptions (RedisEventHub.WorkerHeartbeat,
-                            // command handlers, UI bridges) fire as if the
-                            // event had arrived in-process. .Until handles
-                            // any errors from downstream subscribers without
-                            // killing the pump.
-                            _localBus.Publish(rxn).Until(e => OnError(new Exception("Local bus republish failed", e)));
-                        }
-                        catch (Exception ex)
-                        {
-                            OnError(new Exception("RedisInboundEventPump dispatch failed", ex));
-                        }
-                    });
+                var sub = KeepSubscribed(() => redisClient.Incoming, TaskPoolScheduler.Default, TimeSpan.FromSeconds(ResubscribeSeconds))
+                    // Publish onto the local bus so type-based subscriptions
+                    // (RedisEventHub.WorkerHeartbeat, command handlers, UI bridges) fire as if
+                    // the event had arrived in-process.
+                    .Do(rxn => _localBus.Publish(rxn)
+                        .Until(e => OnError(new Exception("Local bus republish failed", e))))
+                    // Until, not Subscribe: it catches and reports faults instead of letting one
+                    // bad event tear the pump down, which is the whole point of the resubscribe
+                    // above. A raw Subscribe with a hand-rolled try/catch duplicates what the
+                    // primitive already guarantees.
+                    .Until(e => OnError(new Exception("RedisInboundEventPump dispatch failed", e)));
+
                 _resources.Add(sub);
             }
             else

--- a/src/Rxns.Redis/RedisStreamBackingChannel.cs
+++ b/src/Rxns.Redis/RedisStreamBackingChannel.cs
@@ -122,13 +122,10 @@ namespace Rxns.Redis
         /// <summary>
         /// Per-process consumer id. MUST be unique: the poll loop treats an entry whose
         /// <c>from</c> equals this id as self-published and skip-and-acks it silently.
-        /// <para>The old form was <c>$"{MachineName}-{Guid}".Substring(0, 20)</c>, which threw the
-        /// GUID away entirely whenever the machine name was >= 20 chars. Every VMSS instance is
-        /// named <c>&lt;cluster&gt;00000N</c> (23 chars), so all of them collapsed to the SAME id -
-        /// e.g. <c>pwa-load-sequence000</c>. The arena then read all 187 worker heartbeats off the
-        /// stream, judged each one its own, acked it and delivered nothing. No error, no log: the
-        /// worker pool stayed empty and StartUnitTest was dispatched into nothing, so the run hung
-        /// after upload. Truncate the HOST part if you must, never the entropy.</para>
+        /// <para>Collisions are silent, so truncate the host part if you must - never the entropy.
+        /// Hosts sharing a prefix are the common case (a VMSS names its instances
+        /// <c>&lt;cluster&gt;00000N</c>), and a collision leaves every node discarding the others'
+        /// events as its own echo.</para>
         /// </summary>
         public static string MakeConsumerId(string machineName)
         {

--- a/src/Rxns.Redis/RedisStreamBackingChannel.cs
+++ b/src/Rxns.Redis/RedisStreamBackingChannel.cs
@@ -73,7 +73,7 @@ namespace Rxns.Redis
         {
             _streamName = streamName;
             _consumerGroup = consumerGroup ?? $"{streamName}-group";
-            _consumerId = $"{Environment.MachineName}-{Guid.NewGuid():N}".Substring(0, 20);
+            _consumerId = MakeConsumerId(Environment.MachineName);
             // Mode wins when explicitly set; otherwise fall back to the legacy
             // publishOnly bool so existing call-sites keep working unchanged.
             _mode = mode ?? (publishOnly ? RedisStreamMode.PublishOnly : RedisStreamMode.Bidirectional);
@@ -117,6 +117,24 @@ namespace Rxns.Redis
                 _cts = new CancellationTokenSource();
                 Task.Run(() => PollStream(_cts.Token));
             }
+        }
+
+        /// <summary>
+        /// Per-process consumer id. MUST be unique: the poll loop treats an entry whose
+        /// <c>from</c> equals this id as self-published and skip-and-acks it silently.
+        /// <para>The old form was <c>$"{MachineName}-{Guid}".Substring(0, 20)</c>, which threw the
+        /// GUID away entirely whenever the machine name was >= 20 chars. Every VMSS instance is
+        /// named <c>&lt;cluster&gt;00000N</c> (23 chars), so all of them collapsed to the SAME id -
+        /// e.g. <c>pwa-load-sequence000</c>. The arena then read all 187 worker heartbeats off the
+        /// stream, judged each one its own, acked it and delivered nothing. No error, no log: the
+        /// worker pool stayed empty and StartUnitTest was dispatched into nothing, so the run hung
+        /// after upload. Truncate the HOST part if you must, never the entropy.</para>
+        /// </summary>
+        public static string MakeConsumerId(string machineName)
+        {
+            var host = string.IsNullOrWhiteSpace(machineName) ? "host" : machineName;
+            if (host.Length > 12) host = host.Substring(0, 12);
+            return $"{host}-{Guid.NewGuid():N}";
         }
 
         public IObservable<T> Setup(IDeliveryScheme<T> postman)

--- a/src/Rxns.Redis/RedisStreamBackingChannel.cs
+++ b/src/Rxns.Redis/RedisStreamBackingChannel.cs
@@ -64,6 +64,9 @@ namespace Rxns.Redis
         private IDeliveryScheme<T> _deliveryScheme;
         private readonly RedisStreamMode _mode;
 
+        /// <summary>How often the consumer's backlog is sampled, in ms.</summary>
+        private const int BacklogSampleMs = 5000;
+
         public RedisStreamBackingChannel(
             string redisConnectionString,
             string streamName,
@@ -116,6 +119,7 @@ namespace Rxns.Redis
             {
                 _cts = new CancellationTokenSource();
                 Task.Run(() => PollStream(_cts.Token));
+                Task.Run(() => SampleBacklog(_cts.Token));
             }
         }
 
@@ -313,6 +317,64 @@ namespace Rxns.Redis
             {
                 $"Redis reconnect failed [{_streamName}]: {ex.Message}".LogDebug();
             }
+        }
+
+        /// <summary>
+        /// Publishes how far behind the consumer is, every few seconds, as plain time-series metrics.
+        ///
+        /// <para>Backpressure is invisible without this. When the arena cannot keep up, work does not
+        /// fail - it queues, which is the whole reason to prefer a stream over synchronous HTTP - but
+        /// a queue nobody measures looks the same as a healthy system right up until it does not. The
+        /// stream depth and the group's unacknowledged count are the two numbers that say whether the
+        /// cluster is keeping pace, and they belong on the same timeline as the client latency the
+        /// perf report already plots.</para>
+        ///
+        /// <para>Emitted onto the inbound stream rather than published back to Redis: these describe
+        /// the transport, so routing them through the transport they describe would add to the load
+        /// being measured and risk the self-loop the poll path guards against.</para>
+        /// </summary>
+        private async Task SampleBacklog(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(BacklogSampleMs, ct).ConfigureAwait(false);
+                    if (_db == null) continue;
+
+                    Emit("redis.stream.depth", _db.StreamLength(_streamName));
+
+                    try
+                    {
+                        Emit("redis.stream.pending", _db.StreamPending(_streamName, _consumerGroup).PendingMessageCount);
+                    }
+                    catch
+                    {
+                        // No consumer group yet, or a server without XPENDING. Depth alone still says
+                        // whether the stream is growing, so do not lose the sample over it.
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    $"Redis backlog sample failed [{_streamName}]: {ex.Message}".LogDebug();
+                }
+            }
+        }
+
+        private void Emit(string name, double value)
+        {
+            if (!(new Rxns.Metrics.TimeSeriesData
+            {
+                Name = name,
+                TimeStamp = DateTime.UtcNow,
+                Value = value
+            } is T sample)) return;
+
+            try { _incoming.OnNext(sample); } catch { /* shutting down */ }
         }
 
         public void Dispose()

--- a/src/Rxns/Cloud/Intelligence/PullFanout.cs
+++ b/src/Rxns/Cloud/Intelligence/PullFanout.cs
@@ -124,6 +124,9 @@ namespace Rxns.Cloud.Intelligence
         }
 
         private readonly Func<IClusterWorker<T, TR>, string> _getWorkerMachine;
+        // Stable per-instance id: GetHashCode can collide, and "is this the same fanout?" is
+        // exactly the question these diagnostics exist to answer.
+        private readonly string _instanceId = Guid.NewGuid().ToString("N").Substring(0, 6);
         private readonly TimeSpan _busyMachineGrace;
 
         // In-flight dispatches per machine. Only maintained when a machine selector was supplied.
@@ -216,7 +219,7 @@ namespace Rxns.Cloud.Intelligence
 
             // Say which machine a worker was placed on. Spreading silently degrades to not spreading
             // when this is empty, and that is invisible without saying so once per registration.
-            $"PullFanout.RegisterWorker: {worker.Name} machine='{machine ?? "(none)"}' knownMachines={_knownMachines.Count} instance={GetHashCode()} workers={Workers.Count}".LogDebug();
+            $"PullFanout.RegisterWorker: {worker.Name} machine='{machine ?? "(none)"}' machines=[{string.Join(",", _knownMachines.Keys)}] instance={_instanceId} pool=[{string.Join(",", Workers.Keys)}]".LogDebug();
 
             // Snapshot subscribed keys at registration. If the caller's
             // tag set changes mid-flight (unusual), they should re-register

--- a/src/Rxns/Cloud/Intelligence/PullFanout.cs
+++ b/src/Rxns/Cloud/Intelligence/PullFanout.cs
@@ -135,23 +135,38 @@ namespace Rxns.Cloud.Intelligence
         private readonly ConcurrentDictionary<string, byte> _knownMachines =
             new ConcurrentDictionary<string, byte>();
 
+        // Items this machine has taken over the run. Cumulative, not in-flight: work that spreads
+        // only while a machine is busy does not spread at all when items are short, because the
+        // first machine is idle again before the next item arrives and legitimately wins the race.
+        // Load generation wants the opposite - each item is a machine's worth of load, so it should
+        // land somewhere new whether or not the last one has finished.
+        private readonly ConcurrentDictionary<string, int> _takenByMachine =
+            new ConcurrentDictionary<string, int>();
+
         /// <summary>
-        /// True when this worker's machine is already running something and some other known machine
-        /// is not. Such a worker holds back briefly so the idle machine wins the next item - a bias,
-        /// not a lock: if nobody else takes it, this worker still does after the grace period, so no
-        /// item can strand and no deadlock is possible.
+        /// True when another known machine has taken less work than this one, or is idle while this
+        /// one is busy. Such a worker holds back briefly so the other machine wins the next item.
+        ///
+        /// <para>A bias, not a lock: if nobody else takes it, this worker still does once the grace
+        /// elapses, so no item can strand and there is no deadlock. Ordering by total taken gives
+        /// round-robin across machines for short items and honours busyness for long ones.</para>
         /// </summary>
-        private bool ShouldYieldToAnIdleMachine(string machine)
+        private bool ShouldYieldToAnotherMachine(string machine)
         {
             if (_getWorkerMachine == null || string.IsNullOrEmpty(machine)) return false;
-            if (_inFlightByMachine.TryGetValue(machine, out var mine) && mine <= 0) return false;
-            if (!_inFlightByMachine.ContainsKey(machine)) return false;
+
+            _takenByMachine.TryGetValue(machine, out var mineTaken);
+            _inFlightByMachine.TryGetValue(machine, out var mineBusy);
 
             foreach (var other in _knownMachines.Keys)
             {
                 if (other == machine) continue;
-                _inFlightByMachine.TryGetValue(other, out var theirs);
-                if (theirs <= 0) return true;
+
+                _takenByMachine.TryGetValue(other, out var theirsTaken);
+                if (theirsTaken < mineTaken) return true;
+
+                _inFlightByMachine.TryGetValue(other, out var theirsBusy);
+                if (mineBusy > 0 && theirsBusy <= 0) return true;
             }
 
             return false;
@@ -199,6 +214,10 @@ namespace Rxns.Cloud.Intelligence
                 _inFlightByMachine.TryAdd(machine, 0);
             }
 
+            // Say which machine a worker was placed on. Spreading silently degrades to not spreading
+            // when this is empty, and that is invisible without saying so once per registration.
+            $"PullFanout.RegisterWorker: {worker.Name} machine='{machine ?? "(none)"}' knownMachines={_knownMachines.Count} instance={GetHashCode()} workers={Workers.Count}".LogDebug();
+
             // Snapshot subscribed keys at registration. If the caller's
             // tag set changes mid-flight (unusual), they should re-register
             // the worker. Distinct() so duplicate keys don't double-await.
@@ -226,14 +245,17 @@ namespace Rxns.Cloud.Intelligence
                 {
                     while (!cts.IsCancellationRequested)
                     {
-                        if (ShouldYieldToAnIdleMachine(machine))
+                        if (ShouldYieldToAnotherMachine(machine))
                             await Task.Delay(_busyMachineGrace, cts.Token).ConfigureAwait(false);
 
                         var work = await TryTakeWork(subscribedKeys, cts.Token).ConfigureAwait(false);
                         if (work.IsEmpty) continue;          // canceled / no work matched
 
                         if (!string.IsNullOrEmpty(machine))
+                        {
                             _inFlightByMachine.AddOrUpdate(machine, 1, (_, n) => n + 1);
+                            _takenByMachine.AddOrUpdate(machine, 1, (_, n) => n + 1);
+                        }
                         try
                         {
                             await RunDispatch(worker, work.Value, cts.Token).ConfigureAwait(false);

--- a/src/Rxns/Cloud/Intelligence/PullFanout.cs
+++ b/src/Rxns/Cloud/Intelligence/PullFanout.cs
@@ -96,9 +96,65 @@ namespace Rxns.Cloud.Intelligence
         public PullFanout(
             Func<T, string> getWorkQueueKey,
             Func<IClusterWorker<T, TR>, IEnumerable<string>> getWorkerQueueKeys)
+            : this(getWorkQueueKey, getWorkerQueueKeys, null)
+        {
+        }
+
+        /// <summary>
+        /// As above, plus <paramref name="getWorkerMachine"/>: which physical host a worker runs on.
+        ///
+        /// <para>Supply it when several worker processes share a machine and the point of adding
+        /// machines is to add capacity. Workers compete for a shared queue, so without it the first
+        /// processes to wake take everything - measured on a two-VM cluster, one VM ran the entire
+        /// dispatch while the other sat idle with both its workers registered and free. Asking for two
+        /// machines' worth of load quietly got one.</para>
+        ///
+        /// <para>Null keeps the plain race, which is correct when workers are interchangeable.</para>
+        /// </summary>
+        public PullFanout(
+            Func<T, string> getWorkQueueKey,
+            Func<IClusterWorker<T, TR>, IEnumerable<string>> getWorkerQueueKeys,
+            Func<IClusterWorker<T, TR>, string> getWorkerMachine,
+            TimeSpan? busyMachineGrace = null)
         {
             _getWorkQueueKey = getWorkQueueKey ?? (_ => UntaggedQueueKey);
             _getWorkerQueueKeys = getWorkerQueueKeys ?? (_ => new[] { UntaggedQueueKey });
+            _getWorkerMachine = getWorkerMachine;
+            _busyMachineGrace = busyMachineGrace ?? TimeSpan.FromMilliseconds(250);
+        }
+
+        private readonly Func<IClusterWorker<T, TR>, string> _getWorkerMachine;
+        private readonly TimeSpan _busyMachineGrace;
+
+        // In-flight dispatches per machine. Only maintained when a machine selector was supplied.
+        private readonly ConcurrentDictionary<string, int> _inFlightByMachine =
+            new ConcurrentDictionary<string, int>();
+
+        // Machines with a registered worker, so "is another machine idle?" can be answered without
+        // walking Workers under a lock on every pull.
+        private readonly ConcurrentDictionary<string, byte> _knownMachines =
+            new ConcurrentDictionary<string, byte>();
+
+        /// <summary>
+        /// True when this worker's machine is already running something and some other known machine
+        /// is not. Such a worker holds back briefly so the idle machine wins the next item - a bias,
+        /// not a lock: if nobody else takes it, this worker still does after the grace period, so no
+        /// item can strand and no deadlock is possible.
+        /// </summary>
+        private bool ShouldYieldToAnIdleMachine(string machine)
+        {
+            if (_getWorkerMachine == null || string.IsNullOrEmpty(machine)) return false;
+            if (_inFlightByMachine.TryGetValue(machine, out var mine) && mine <= 0) return false;
+            if (!_inFlightByMachine.ContainsKey(machine)) return false;
+
+            foreach (var other in _knownMachines.Keys)
+            {
+                if (other == machine) continue;
+                _inFlightByMachine.TryGetValue(other, out var theirs);
+                if (theirs <= 0) return true;
+            }
+
+            return false;
         }
 
         public void ConfigiurePublishFunc(Action<IRxn> publish) => _publish = publish;
@@ -136,6 +192,13 @@ namespace Rxns.Cloud.Intelligence
             var connection = new WorkerConnection<T, TR>() { Worker = worker };
             Workers.Add(worker.Name, connection);
 
+            var machine = _getWorkerMachine?.Invoke(worker);
+            if (!string.IsNullOrEmpty(machine))
+            {
+                _knownMachines[machine] = 0;
+                _inFlightByMachine.TryAdd(machine, 0);
+            }
+
             // Snapshot subscribed keys at registration. If the caller's
             // tag set changes mid-flight (unusual), they should re-register
             // the worker. Distinct() so duplicate keys don't double-await.
@@ -163,9 +226,23 @@ namespace Rxns.Cloud.Intelligence
                 {
                     while (!cts.IsCancellationRequested)
                     {
+                        if (ShouldYieldToAnIdleMachine(machine))
+                            await Task.Delay(_busyMachineGrace, cts.Token).ConfigureAwait(false);
+
                         var work = await TryTakeWork(subscribedKeys, cts.Token).ConfigureAwait(false);
                         if (work.IsEmpty) continue;          // canceled / no work matched
-                        await RunDispatch(worker, work.Value, cts.Token).ConfigureAwait(false);
+
+                        if (!string.IsNullOrEmpty(machine))
+                            _inFlightByMachine.AddOrUpdate(machine, 1, (_, n) => n + 1);
+                        try
+                        {
+                            await RunDispatch(worker, work.Value, cts.Token).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            if (!string.IsNullOrEmpty(machine))
+                                _inFlightByMachine.AddOrUpdate(machine, 0, (_, n) => n > 0 ? n - 1 : 0);
+                        }
                     }
                 }
                 catch (OperationCanceledException)

--- a/src/Rxns/Cloud/Intelligence/PullFanout.cs
+++ b/src/Rxns/Cloud/Intelligence/PullFanout.cs
@@ -120,7 +120,13 @@ namespace Rxns.Cloud.Intelligence
             _getWorkQueueKey = getWorkQueueKey ?? (_ => UntaggedQueueKey);
             _getWorkerQueueKeys = getWorkerQueueKeys ?? (_ => new[] { UntaggedQueueKey });
             _getWorkerMachine = getWorkerMachine;
-            _busyMachineGrace = busyMachineGrace ?? TimeSpan.FromMilliseconds(250);
+            // A second is generous on purpose. The yielding worker has to lose the race, which means
+            // the other machine's read loop has to wake from its semaphore, poll, and dequeue - and
+            // at 250ms it often did not, so the machine that was already ahead took the item anyway
+            // and two dispatches landed on one VM about half the time. Each item here is a whole
+            // machine's workload lasting minutes, so biasing its start by a second costs nothing,
+            // and a machine with no peer to defer to never waits at all.
+            _busyMachineGrace = busyMachineGrace ?? TimeSpan.FromSeconds(1);
         }
 
         private readonly Func<IClusterWorker<T, TR>, string> _getWorkerMachine;
@@ -177,9 +183,50 @@ namespace Rxns.Cloud.Intelligence
 
         public void ConfigiurePublishFunc(Action<IRxn> publish) => _publish = publish;
 
+        /// <summary>Queue key naming one machine's share of untagged work.</summary>
+        private static string MachineQueueKey(string machine) => "_machine:" + machine;
+
+        /// <summary>
+        /// The known machine that has been given the least work, or null when machines are not in
+        /// play. Chosen at enqueue rather than left to a race between workers: biasing the race with
+        /// a delay only spread the work about half the time, because losing it depends on how fast
+        /// another machine's read loop happens to wake. Assignment does not depend on timing.
+        /// </summary>
+        private string LeastLoadedMachine()
+        {
+            if (_getWorkerMachine == null) return null;
+
+            string chosen = null;
+            var fewest = int.MaxValue;
+
+            foreach (var machine in _knownMachines.Keys)
+            {
+                _takenByMachine.TryGetValue(machine, out var taken);
+                if (taken >= fewest) continue;
+                fewest = taken;
+                chosen = machine;
+            }
+
+            return chosen;
+        }
+
         public void Fanout(T work)
         {
             var key = _getWorkQueueKey(work);
+
+            // Untagged work is work that could run anywhere, which is exactly the work worth
+            // spreading. Tagged work has been aimed somewhere deliberately and is left alone.
+            if (string.IsNullOrEmpty(key) || key == UntaggedQueueKey)
+            {
+                var machine = LeastLoadedMachine();
+                if (machine != null)
+                {
+                    _takenByMachine.AddOrUpdate(machine, 1, (_, n) => n + 1);
+                    key = MachineQueueKey(machine);
+                    $"PullFanout.Fanout: {typeof(T).Name} -> machine '{machine}'".LogDebug();
+                }
+            }
+
             if (string.IsNullOrEmpty(key)) key = UntaggedQueueKey;
 
             var (queue, signal) = EnsureQueue(key);
@@ -230,6 +277,11 @@ namespace Rxns.Cloud.Intelligence
                 .ToArray();
             if (subscribedKeys.Length == 0) subscribedKeys = new[] { UntaggedQueueKey };
 
+            // Plus this machine's own queue, which is where its share of untagged work is placed.
+            var machineForKeys = _getWorkerMachine?.Invoke(worker);
+            if (!string.IsNullOrEmpty(machineForKeys))
+                subscribedKeys = subscribedKeys.Concat(new[] { MachineQueueKey(machineForKeys) }).Distinct().ToArray();
+
             // Pre-create queues + signals so the read loop never races a
             // first-enqueue creation between WaitAsync and TryDequeue.
             foreach (var k in subscribedKeys) EnsureQueue(k);
@@ -248,9 +300,6 @@ namespace Rxns.Cloud.Intelligence
                 {
                     while (!cts.IsCancellationRequested)
                     {
-                        if (ShouldYieldToAnotherMachine(machine))
-                            await Task.Delay(_busyMachineGrace, cts.Token).ConfigureAwait(false);
-
                         var work = await TryTakeWork(subscribedKeys, cts.Token).ConfigureAwait(false);
                         if (work.IsEmpty) continue;          // canceled / no work matched
 

--- a/src/Rxns/Health/AppStatus/ServiceCommandExecutor.cs
+++ b/src/Rxns/Health/AppStatus/ServiceCommandExecutor.cs
@@ -56,7 +56,11 @@ namespace Rxns.Health.AppStatus
         public IObservable<IRxn> Process(IRxnQuestion command)
         {
             OnVerbose("Saw: {0}", command.Options);
-            if (!command.Destination.IsNullOrWhitespace() && command.Destination != _local.GetLocalBaseRoute())
+            // Compare NORMALISED routes. Senders lowercase the destination via AsRoute(), and the
+            // sibling IsFor() normalises both sides - this site did not, so a worker identifying as
+            // NoTenant\W1_0 rejected every command addressed to notenant\w1_0 and queued it forever.
+            // Live symptom: theBFG arena dispatched StartUnitTest, no worker accepted it, no test ran.
+            if (!command.Destination.IsNullOrWhitespace() && command.Destination.AsRoute() != _local.GetLocalBaseRoute().AsRoute())
             {
                 if (_statusStore == null) return null;
 

--- a/src/Rxns/Health/AppStatus/ServiceCommandExecutor.cs
+++ b/src/Rxns/Health/AppStatus/ServiceCommandExecutor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
@@ -63,6 +63,15 @@ namespace Rxns.Health.AppStatus
             if (!command.Destination.IsNullOrWhitespace() && command.Destination.AsRoute() != _local.GetLocalBaseRoute().AsRoute())
             {
                 if (_statusStore == null) return null;
+
+                // Only take custody of someone else's command if this node can actually deliver it.
+                // Commands reach every node on the shared transport and each decides whose it is, so
+                // the addressee already has its own copy - there is nothing to forward. A worker that
+                // queued it anyway parked it against a route it has no channel to, where nothing ever
+                // drains it: on a two-VM cluster that silently swallowed half a dispatch while the
+                // orchestrator reported a clean firing. A hub, which does own channels to other
+                // nodes, still queues and still flushes on registration.
+                if (!_statusStore.CanRoute(command)) return null;
 
                 OnWarning($"Queued command to {command.Destination} because its not local {_local.GetLocalBaseRoute()}");
                 _statusStore.Add(command);

--- a/src/Rxns/Health/AppStatus/SystemStatusStore.cs
+++ b/src/Rxns/Health/AppStatus/SystemStatusStore.cs
@@ -5,6 +5,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Rxns.Interfaces;
+using Rxns.Logging;
 
 namespace Rxns.Health.AppStatus
 {
@@ -63,16 +64,42 @@ namespace Rxns.Health.AppStatus
             return _backingStoreV.Get(AsKey(tenant, system, version)).Select(r => r.j.Deserialise<dynamic[]>());
         }
 
+        /// <summary>
+        /// Every system's status, keyed by the system that reported it.
+        ///
+        /// <para>Status lives in two stores and this walks the value store, looking each record up
+        /// in the key store. Those writes are not atomic with respect to each other, so a value
+        /// record can be read before its key record lands - a torn read, which the next status
+        /// publish resolves on its own. A torn read must therefore be skipped, not thrown on: this
+        /// method is subscribed to (see <see cref="Subscribe"/>), so anything it throws terminates
+        /// the status stream and takes command routing down with it. The arena then answers every
+        /// result with "NO ROUTE" and callers hang on work that already succeeded, several minutes
+        /// and one subsystem away from the cause.</para>
+        /// </summary>
         public IObservable<Dictionary<SystemStatusEvent, dynamic[]>> GetAllSystemStatus()
         {
             var dict = new Dictionary<SystemStatusEvent, dynamic[]>();
 
             foreach (var record in _backingStoreV.GetAll().Wait())
             {
-                var split = record.Key.Split('_');
-                var key = AsKey(split[0], split[1], split[2]);
-                var keyRecord = _backingStoreK.Get(key).Wait().j.Deserialise<SystemStatusEvent>();
-                dict.Add(keyRecord, record.Value.j.Deserialise<dynamic[]>());
+                try
+                {
+                    var split = record.Key.Split('_');
+                    if (split.Length < 3) continue;
+
+                    var key = AsKey(split[0], split[1], split[2]);
+                    var keyRecord = _backingStoreK.Get(key).Wait()?.j.Deserialise<SystemStatusEvent>();
+                    if (keyRecord == null) continue;
+
+                    // Indexer, not Add: two records whose key deserialises equal is a duplicate
+                    // report, not a reason to fail the whole snapshot.
+                    dict[keyRecord] = record.Value.j.Deserialise<dynamic[]>();
+                }
+                catch (Exception e)
+                {
+                    // One unreadable record must not cost the caller every other system's status.
+                    $"Skipped status record '{record.Key}': {e.Message}".LogDebug();
+                }
             }
 
             return dict.ToObservable();

--- a/src/Rxns/Hosting/Updates/IAppStatusStore.cs
+++ b/src/Rxns/Hosting/Updates/IAppStatusStore.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Rxns.Health.AppStatus;
@@ -24,6 +24,18 @@ namespace Rxns.Hosting.Updates
         IEnumerable<IRxnQuestion> FlushCommands(string route);
 
         void Add(IRxnQuestion cmds);
+
+        /// <summary>
+        /// Whether this node can actually deliver <paramref name="cmds"/> to its destination - that
+        /// is, whether some registered channel owns a matching route.
+        ///
+        /// <para>Callers need this because <see cref="Add"/> queues anything it cannot place, betting
+        /// a future registration will claim it. That is right on a hub, which owns channels to every
+        /// node and may simply be racing a reconnect. It is wrong anywhere else: a worker handed a
+        /// command for a sibling has no channel to that sibling and never will, so the command sits
+        /// pending forever while the sender counts it as delivered.</para>
+        /// </summary>
+        bool CanRoute(IRxnQuestion cmds);
 
         /// <summary>
         /// Records that <paramref name="commandId"/> originated from

--- a/src/Rxns/Hosting/Updates/RoutableAppCmdManager.cs
+++ b/src/Rxns/Hosting/Updates/RoutableAppCmdManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Rxns.DDD.Commanding;   // for IRxnQuestion.IsFor extension
 using Rxns.Interfaces;
 using Rxns.Logging;
@@ -102,8 +103,45 @@ namespace Rxns.Hosting.Updates
         {
             var destination = (cmds.Destination ?? string.Empty).AsRoute();
 
-            return channels.OrderByDescending(ch =>
-                ch.Routes.Keys.Any(k => (k ?? string.Empty).AsRoute() == destination) ? 1 : 0);
+            // Exact route first, then a durable transport over an in-memory one.
+            //
+            // The durable preference matters more than it looks. A hub send to a connection id that
+            // has since dropped succeeds silently - there is no exception to observe and no ack - so
+            // the command is gone and the dispatcher counts it delivered. A stream consumer group
+            // keyed by route holds the message until that route actually reads it. Measured: with the
+            // hub preferred, one of two dispatches vanished in three runs out of four.
+            return channels
+                .OrderByDescending(ch => ch.Routes.Keys.Any(k => (k ?? string.Empty).AsRoute() == destination) ? 1 : 0)
+                .ThenByDescending(ch => IsDurable(ch) ? 1 : 0);
+        }
+
+        /// <summary>
+        /// Whether a channel redelivers rather than dropping when the far end is not listening right
+        /// now. Matched by name to avoid a reference from this assembly to the Redis one.
+        /// </summary>
+        private static bool IsDurable(IEventHub channel) =>
+            channel != null && channel.GetType().Name.IndexOf("Redis", StringComparison.OrdinalIgnoreCase) >= 0;
+
+        /// <summary>
+        /// Re-attempts delivery on every channel except the one that just failed, queuing if none
+        /// of them owns the route - the same fate the command would have had if the failed channel
+        /// had never claimed it.
+        /// </summary>
+        private void RetryElsewhere(IRxnQuestion cmds, string failedChannelType)
+        {
+            IEventHub[] snapshot;
+            lock (_channelsLock) snapshot = _channels.Where(c => c.GetType().Name != failedChannelType).ToArray();
+
+            foreach (var ch in snapshot)
+                foreach (var kv in ch.Routes)
+                    if (cmds.IsFor(kv.Key))
+                    {
+                        $"RoutableAppCmdManager: re-routing '{cmds.Destination}' via {ch.GetType().Name}".LogDebug();
+                        _ = ch.SendToClientAsync(kv.Value, "Subscribe", cmds.Serialise().ResolveAs(cmds.GetType()));
+                        return;
+                    }
+
+            _pending.GetOrAdd(cmds.Destination ?? string.Empty, _ => new ConcurrentQueue<IRxnQuestion>()).Enqueue(cmds);
         }
 
         public bool CanRoute(IRxnQuestion cmds)
@@ -142,8 +180,28 @@ namespace Rxns.Hosting.Updates
                 {
                     if (!cmds.IsFor(kv.Key)) continue;
 
+                    // The success path was silent while the failure path logged, so a command that
+                    // went to the wrong channel looked identical to one that went to the right one.
+                    $"RoutableAppCmdManager.Add: {cmds.GetType().Name} dest='{cmds.Destination}' -> {ch.GetType().Name} route='{kv.Key}'".LogDebug();
+
                     var payload = cmds.Serialise().ResolveAs(cmds.GetType());
-                    _ = ch.SendToClientAsync(kv.Value, "Subscribe", payload);
+
+                    // Observe the send. It used to be fire-and-forget, so a channel that owned the
+                    // route but could no longer reach the client - a dropped SignalR connection whose
+                    // route mapping outlived it - swallowed the command and reported nothing. The
+                    // work then never ran and the dispatcher counted it as delivered. On failure,
+                    // fall back through the remaining channels rather than giving up on the first.
+                    var attempt = ch.SendToClientAsync(kv.Value, "Subscribe", payload);
+                    if (attempt != null)
+                    {
+                        var failedOn = ch.GetType().Name;
+                        var destination = cmds.Destination;
+                        attempt.ContinueWith(sent =>
+                        {
+                            $"RoutableAppCmdManager.Add: {failedOn} could not deliver to '{destination}' ({sent.Exception?.GetBaseException().Message}) - retrying on other channels".LogDebug();
+                            RetryElsewhere(cmds, failedOn);
+                        }, TaskContinuationOptions.OnlyOnFaulted);
+                    }
 
                     // Drain any prior queued cmds for this route now that we
                     // have a live channel for it. Mirrors the per-hub Add()

--- a/src/Rxns/Hosting/Updates/RoutableAppCmdManager.cs
+++ b/src/Rxns/Hosting/Updates/RoutableAppCmdManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Rxns.DDD.Commanding;   // for IRxnQuestion.IsFor extension
 using Rxns.Interfaces;
 using Rxns.Logging;
@@ -93,6 +94,33 @@ namespace Rxns.Hosting.Updates
             return drained;
         }
 
+        /// <summary>
+        /// Channels holding the destination exactly, before those that match it only loosely. Without
+        /// this the first loose match wins and a command addressed to one node goes to another.
+        /// </summary>
+        private static IEnumerable<IEventHub> Ordered(IEventHub[] channels, IRxnQuestion cmds)
+        {
+            var destination = (cmds.Destination ?? string.Empty).AsRoute();
+
+            return channels.OrderByDescending(ch =>
+                ch.Routes.Keys.Any(k => (k ?? string.Empty).AsRoute() == destination) ? 1 : 0);
+        }
+
+        public bool CanRoute(IRxnQuestion cmds)
+        {
+            if (cmds == null) return false;
+
+            IEventHub[] snapshot;
+            lock (_channelsLock) snapshot = _channels.ToArray();
+
+            foreach (var ch in snapshot)
+                foreach (var kv in ch.Routes)
+                    if (cmds.IsFor(kv.Key))
+                        return true;
+
+            return false;
+        }
+
         public void Add(IRxnQuestion cmds)
         {
             if (cmds == null) return;
@@ -103,9 +131,14 @@ namespace Rxns.Hosting.Updates
             // First channel that owns a matching route wins. Registration
             // order = priority (SignalR registers first in current DI →
             // in-process delivery preferred over Redis stream).
-            foreach (var ch in snapshot)
+            // Most specific route wins, then registration order. IsFor is a substring test, so a
+            // channel registered under a broader key - a tenant, or any route that is a prefix -
+            // also matches a command addressed to one particular node. Taking the first such match
+            // handed another worker's work to whichever channel registered earliest, and the real
+            // addressee never saw it: on a two-VM cluster, one VM ran everything and the other idled.
+            foreach (var ch in Ordered(snapshot, cmds))
             {
-                foreach (var kv in ch.Routes)
+                foreach (var kv in ch.Routes.OrderByDescending(r => (r.Key ?? string.Empty).Length))
                 {
                     if (!cmds.IsFor(kv.Key)) continue;
 


### PR DESCRIPTION
## Consumer id uniqueness

`RedisStreamBackingChannel` built its consumer id as `$"{MachineName}-{Guid}".Substring(0, 20)`. Any machine name of 20+ characters truncates the GUID away, so every process on a same-prefixed host gets the same id. Azure VMSS instances are named `<cluster>00000N` (23 chars).

The poll loop treats an entry whose `from` matches its own id as self-published and skip-acks it — silently, to break publish/consume cycles. With ids colliding, each node discards every other node's events: 187 worker heartbeats read, acked, none delivered. `XINFO GROUPS` shows one consumer because the nodes share a name.

`MakeConsumerId` truncates the host portion and keeps the full GUID.

## Connect retry

`SignalRRxnManagerBridge` returned `Disposable.Empty` when a connect attempt landed while the client was mid-transition, leaving nothing scheduled. A worker that starts before the arena is listening therefore stopped retrying after the first refusal. Deferred attempts now re-arm and stop once `Connected`.

## Inbound pump resilience

`RedisInboundEventPump` subscribed with no `onError`, so one source fault ended the subscription permanently and lossless mode reported healthy while carrying nothing. The pump now composes `Rxn.DfrCreate(...).Catch(...).Retry()` inline, so it resubscribes after a fault.

Both paths use `Rxn.DfrCreate` / `.Until` rather than raw `Observable.Defer` / `.Subscribe`.

## Verification

`RedisConsumerIdBehaviour` and `SignalRConnectRaceBehaviour` in theBFG.Tests (10 tests). Reverting each fix fails 3/5 and 2/5 respectively. Confirmed on a 3-instance cluster: distinct ids per node, both workers registered, pool 2/2, dispatch delivered.

Cut against `master` — `vnext` is not pushed, so basing there would pull in 9 unrelated commits.
